### PR TITLE
requirements.txt: bump Twisted dep to >=14.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-Twisted>=10.1
+Twisted>=14.0.0
 Parsley>=1.2


### PR DESCRIPTION
This is the first Twisted release that included
twisted.internet.interfaces.IStreamClientEndpointStringParserWithReactor,
which is needed by txi2p/plugins.py .

Without this, clients (in particular, the foolscap buildbot environment that tests old Twisteds) can mistakenly think they can run with an older Twisted, but at runtime they get an import error.
