### PR TITLE
travis: remove --use-mirrors to work with pip>=7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
     - python: pypy
 
 install:
-  - pip install $TWISTED coveralls --use-mirrors
-  - pip install -r requirements.txt --use-mirrors
+  - pip install $TWISTED coveralls
+  - pip install -r requirements.txt
 
 script: coverage run $(which trial) txi2p
 after_success: "coveralls"


### PR DESCRIPTION
It looks like travis isn't running at all, because it's using an outdated pip option.
